### PR TITLE
node-restify was previously udpated to 2.0 from 1.4.

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,11 +21,7 @@ var Logger = require('bunyan');
 var log = new Logger({
     name: 'boilerplateapi',
     level: 'debug',
-    serializers: {
-        err: Logger.stdSerializers.err,
-        req: Logger.stdSerializers.req,
-        res: restify.bunyan.serializers.response
-    }
+    serializers: restify.bunyan.serializers
 });
 
 


### PR DESCRIPTION
- Fix crash: invalid serializer for "res" field.
