### PR TITLE
TRITON-1996 triton-origin-minimal-64-19.4.0 image TRITON-2043 bump min_platform due to pkgsrc 2019Q3 build env changes

### DIFF
--- a/tools/mk/Makefile.defs
+++ b/tools/mk/Makefile.defs
@@ -5,7 +5,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 #
@@ -133,7 +133,7 @@ MAKE_STAMP_CREATE =	mkdir -p $(@D); touch $(@)
 # be running this platform image, validated as part of validate-buildenv.sh.
 # Makefiles that allow newer platforms should override this.
 #
-BUILD_PLATFORM=20151126T062538Z
+BUILD_PLATFORM=20181206T011455Z
 
 #
 # The manta path where the bits-upload target stores build artifacts, via

--- a/tools/mk/Makefile.node_prebuilt.defs
+++ b/tools/mk/Makefile.node_prebuilt.defs
@@ -5,7 +5,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 #
@@ -82,7 +82,8 @@
 #				returns JSON results, with one object per
 #				line.
 #				(default: sdcnode master build dir on
-#				US-East manta for the given branch)
+#				US-East manta for the given branch, built on
+#				the current min_platform, $(BUILD_PLATFORM))
 #
 #
 #	NODE_PREBUILT_TAG	The 'sdcnode' project supports special
@@ -147,7 +148,7 @@ else
 endif
 NODE_PREBUILT_PATTERN := sdcnode-$(NODE_PREBUILT_NAME)-$(NODE_PREBUILT_BRANCH)-.*\.tgz
 NODE_PREBUILT_MANTA_URL ?= https://us-east.manta.joyent.com
-NODE_PREBUILT_MANTA_DIR ?= /Joyent_Dev/public/releng/sdcnode/$(NODE_PREBUILT_IMAGE)/$(NODE_PREBUILT_BRANCH)-latest
+NODE_PREBUILT_MANTA_DIR ?= /Joyent_Dev/public/releng/sdcnode/$(BUILD_PLATFORM)/$(NODE_PREBUILT_IMAGE)/$(NODE_PREBUILT_BRANCH)-latest
 
 # only use NODE_PREBUILT_DIR if it is set.
 ifeq ($(NODE_PREBUILT_DIR),)

--- a/tools/validate-buildenv.sh
+++ b/tools/validate-buildenv.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 #
@@ -36,7 +36,7 @@
 # - the RBAC profiles(1) of the user, looking for 'Primary Administrator' or
 #   uid=0
 # - the build environment has a $PATH with /opt/local/bin before /usr/bin et al
-# - our build platform for this component, BUILD_PLATFORM, matches uname -vish
+# - our build platform for this component matches uname -vish
 # - several non-pkgsrc programs needed by the build are availabe on the $PATH
 # - git submodules for this repository, if present, are up to date
 #
@@ -51,6 +51,7 @@
 #    triton-origin-multiarch-15.4.1@1.0.1: 04a48d7d-6bb5-4e83-8c3b-e60a99e0f48f
 #    minimal-multiarch@18.1.0: 1ad363ec-3b83-11e8-8521-2f68a4a34d5d
 #    triton-origin-multiarch-18.1.0: b6ea7cb4-6b90-48c0-99e7-1d34c2895248
+#    triton-origin-x86_64-19.4.0:
 #
 # In the future, we would prefer if the pkgsrc versions were declared
 # directly in Makefiles without needing this lookup. (see TOOLS-2038)
@@ -89,6 +90,8 @@ declare -A PKGSRC_MAP=(
     [cbf116a0-43a5-447c-ad8c-8fa57787351c]=2019Q1
     [7f4d80b4-9d70-11e9-9388-6b41834cbeeb]=2019Q2
     [a0d5f456-ba0f-4b13-bfdc-5e9323837ca7]=2019Q2
+    [5417ab20-3156-11ea-8b19-2b66f5e7a439]=2019Q4
+    [59ba2e5e-976f-4e09-8aac-a4a7ef0395f5]=2019Q4
 )
 
 # Used to provide useful error messages to the user, mapping the
@@ -105,6 +108,8 @@ declare -A SDC_MAP=(
     [cbf116a0-43a5-447c-ad8c-8fa57787351c]=triton-origin-x86_64-19.1.0@master-20190417T143547Z-g119675b
     [7f4d80b4-9d70-11e9-9388-6b41834cbeeb]=minimal-64@19.2.0
     [a0d5f456-ba0f-4b13-bfdc-5e9323837ca7]=triton-origin-x86_64-19.2.0@master-20190919T182250Z-g363e57e
+    [5417ab20-3156-11ea-8b19-2b66f5e7a439]=minimal-64-lts@19.4.0
+    [59ba2e5e-976f-4e09-8aac-a4a7ef0395f5]=triton-origin-x86_64-19.4.0@master-20200130T200825Z-gbb45b8d
 )
 
 # Used to provide useful error messages to the user, mapping the NODE_PREBUILT
@@ -123,6 +128,8 @@ declare -A JENKINS_AGENT_MAP=(
     [cbf116a0-43a5-447c-ad8c-8fa57787351c]=fb751f94-3202-461d-b98d-4465560945ec
     [7f4d80b4-9d70-11e9-9388-6b41834cbeeb]=c177a02f-5eb7-4dc7-b087-89f86d1f9eec
     [a0d5f456-ba0f-4b13-bfdc-5e9323837ca7]=c177a02f-5eb7-4dc7-b087-89f86d1f9eec
+    [5417ab20-3156-11ea-8b19-2b66f5e7a439]=23a48c86-8b59-4629-a2f1-5dac3cba09b1
+    [59ba2e5e-976f-4e09-8aac-a4a7ef0395f5]=23a48c86-8b59-4629-a2f1-5dac3cba09b1
 )
 
 # For each pkgsrc version, set a list of packages that must be present
@@ -196,6 +203,19 @@ PKGSRC_PKGS_2019Q1="
     rust"
 
 PKGSRC_PKGS_2019Q2="
+    grep
+    build-essential
+    python27
+    py27-expat
+    coreutils
+    gsed
+    gsharutils
+    flex
+    pcre
+    pigz
+    rust"
+
+PKGSRC_PKGS_2019Q4="
     grep
     build-essential
     python27


### PR DESCRIPTION
The timing of this change is important: after it goes back, any Triton/Manta component that switches to it also gets a new min_platform. We need to ensure that components are ready to switch to this en-mass, or perhaps during a phased approach.

We've built all images on the new min_platform and found only two that aren't yet ready to make the switch, for which bugs are in progress.

Finally, we have TOOLS-2428 which is looking to upgrade the CTF tools infrastructure, so we should wait until that lands in eng before proceeding with the component deps/eng bump.