### PR TITLE
TOOLS-2525 Everything needs to stop cloning with git:// URLs (embedded imgapi)

### DIFF
--- a/tools/buildimage/lib/imgadm/package-lock.json
+++ b/tools/buildimage/lib/imgadm/package-lock.json
@@ -941,8 +941,8 @@
       "dev": true
     },
     "fs-ext": {
-      "version": "https://github.com/joyent/node-fs-ext.git#d2c241f230a8b8362997523e42fa5f135202eebb",
-      "from": "https://github.com/joyent/node-fs-ext.git#node-0.10",
+      "version": "git+https://github.com/joyent/node-fs-ext.git#d2c241f230a8b8362997523e42fa5f135202eebb",
+      "from": "git+https://github.com/joyent/node-fs-ext.git#node-0.10",
       "requires": {
         "nan": "^2.14.0"
       }
@@ -2219,10 +2219,11 @@
       "dev": true
     },
     "qlocker": {
-      "version": "git+https://github.com/joyent/node-qlocker.git#1413d3a8d8c6015852e031019df88abd9edd16d8",
-      "from": "git+https://github.com/joyent/node-qlocker.git#1413d3a8d8c6015852e031019df88abd9edd16d8",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/qlocker/-/qlocker-1.0.2.tgz",
+      "integrity": "sha512-/VXDDWrH///e7PT9dVOUKEif7QaQ3NyZPOG38jNgaDiyHiin6ZmANRQFjudmmyQOCO2punVbX5rnv+U4y2F6Qg==",
       "requires": {
-        "fs-ext": "https://github.com/joyent/node-fs-ext.git#node-0.10"
+        "fs-ext": "git+https://github.com/joyent/node-fs-ext.git#node-0.10"
       }
     },
     "qs": {
@@ -2587,8 +2588,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sdc-clients": {
-      "version": "https://github.com/joyent/node-sdc-clients.git#28209abf97928bb3e256ea17a7f532e1b75c6032",
-      "from": "https://github.com/joyent/node-sdc-clients.git#28209ab",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/sdc-clients/-/sdc-clients-13.0.5.tgz",
+      "integrity": "sha512-WO3nPzHnVh7Jp64kGd/i/1wJCSbAM7ZdCr+ewsSOl4DFoanNl1MO/XDGXSTttqecNgRDCuJADY5KKCwqsyyO6w==",
       "requires": {
         "assert-plus": "^1.0.0",
         "async": "~0.9.0",
@@ -2597,11 +2599,9 @@
         "clone": "0.1.8",
         "jsprim": "1.4.1",
         "lomstream": "1.1.0",
-        "lru-cache": "2.3.0",
         "once": "^1.3.1",
         "restify-clients": "^1.6.0",
-        "restify-errors": "^3.0.0",
-        "smartdc-auth": "2.5.2",
+        "smartdc-auth": "2.5.7",
         "sshpk": "^1.10.1",
         "vasync": "^1.6.2",
         "verror": "^1.6.0"
@@ -2619,11 +2619,6 @@
           "requires": {
             "precond": "0.2"
           }
-        },
-        "lru-cache": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.0.tgz",
-          "integrity": "sha1-HO4S1anyjtHuN+nDMriIjmuFQSo="
         }
       }
     },
@@ -2670,12 +2665,12 @@
       "dev": true
     },
     "smartdc-auth": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/smartdc-auth/-/smartdc-auth-2.5.2.tgz",
-      "integrity": "sha1-dPNRGVi25axPHFWJktpgSeHfwDU=",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/smartdc-auth/-/smartdc-auth-2.5.7.tgz",
+      "integrity": "sha1-QtRXEOeR3rkt+RMmyO7RvVqELLY=",
       "requires": {
         "assert-plus": "^1.0.0",
-        "bunyan": "1.5.1",
+        "bunyan": "1.8.12",
         "clone": "0.1.5",
         "dashdash": "1.10.1",
         "http-signature": "^1.0.2",
@@ -2689,16 +2684,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "bunyan": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.5.1.tgz",
-          "integrity": "sha1-X259RMQ7lS9WsPQTCeOrEjkbTi0=",
-          "requires": {
-            "dtrace-provider": "~0.6",
-            "mv": "~2",
-            "safe-json-stringify": "~1"
-          }
         },
         "clone": {
           "version": "0.1.5",
@@ -2718,15 +2703,6 @@
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
               "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
             }
-          }
-        },
-        "dtrace-provider": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
-          "integrity": "sha1-CweNVReTfYcxAUUtkUZzdVe3XlE=",
-          "optional": true,
-          "requires": {
-            "nan": "^2.0.8"
           }
         },
         "extsprintf": {
@@ -3035,9 +3011,9 @@
           }
         },
         "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+          "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
           "requires": {
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",

--- a/tools/buildimage/lib/imgadm/package.json
+++ b/tools/buildimage/lib/imgadm/package.json
@@ -19,10 +19,10 @@
     "node-uuid": "1.4.1",
     "once": "1.3.1",
     "progbar": "1.1.0",
-    "qlocker": "git+https://github.com/joyent/node-qlocker#1413d3a8d8c6015852e031019df88abd9edd16d8",
+    "qlocker": "^1.0.2",
     "restify": "7.2.2",
     "rimraf": "2.2.8",
-    "sdc-clients": "https://github.com/joyent/node-sdc-clients.git#28209ab",
+    "sdc-clients": "^13.0.5",
     "tabula": "1.4.1",
     "vasync": "1.6.2",
     "verror": "1.6.0"


### PR DESCRIPTION
These embedded dependencies were still using `git://` URLs, causing builds to fail.